### PR TITLE
`getIMGT` function more robust 

### DIFF
--- a/R/getIMGT.R
+++ b/R/getIMGT.R
@@ -5,12 +5,14 @@
 #' IMGT can be found at \href{https://www.imgt.org/}{imgt.org}.
 #'
 #' @examples
+#' \dontrun{
 #' TRBV_aa <- getIMGT(species = "human",
 #'                    chain = "TRB",
 #'                    frame = "inframe",
 #'                    region = "v",
 #'                    sequence.type = "aa", 
 #'                    max.retries = 3) 
+#' }
 #'
 #' @param species One or two-word common designation of species. 
 #' @param chain Sequence chain to access, e.g., \strong{TRB} or \strong{IGH}.

--- a/vignettes/immApex.Rmd
+++ b/vignettes/immApex.Rmd
@@ -58,14 +58,31 @@ Parameters for ```getIMGT()```
 
 Here, we will use the ```getIMGT()``` function to get the amino acid sequences for the TRBV region to get all the sequences by V gene allele.
 
-```{r }
-TRBV_aa <- getIMGT(species = "human",
-                   chain = "TRB",
-                   frame = "inframe",
-                   region = "v",
-                   sequence.type = "aa") 
+```{r, eval=knitr::is_html_output()}
+# Function to check IMGT website availability
+is_imgt_available <- function() {
+  tryCatch({
+    r <- httr::HEAD("https://www.imgt.org", timeout(5))
+    httr::status_code(r) == 200
+  }, error = function(e) {
+    FALSE
+  })
+}
 
-TRBV_aa[[1]][1]
+# Run getIMGT only if the website is available
+if (is_imgt_available()) {
+  TRBV_aa <- getIMGT(species = "human",
+                     chain = "TRB",
+                     frame = "inframe",
+                     region = "v",
+                     sequence.type = "aa")
+
+  # Display first sequence as an example
+  TRBV_aa[[1]][1]
+} else {
+  # Display a message if IMGT is not available
+  "IMGT website is not accessible at the moment."
+}
 ```
 
 ## formatGenes


### PR DESCRIPTION
# Changes:

- The `getIMGT` example is now wrapped in `\dontrun{}` to prevent it from running during R CMD check.
- The vignette now includes a check for IMGT website availability before attempting to run the `getIMGT` function, preventing errors when the site is down.